### PR TITLE
Update to domainslib.0.4.0

### DIFF
--- a/code/profiling/float_init_par.ml
+++ b/code/profiling/float_init_par.ml
@@ -5,7 +5,7 @@ let n = try int_of_string Sys.argv.(2) with _ -> 100000
 let a = Array.create_float n
 
 let _ =
-  let pool = Task.setup_pool ~num_additional_domains:(num_domains-1) in
-  Task.parallel_for pool ~chunk_size:(n/num_domains) ~start:0
-  ~finish:(n - 1) ~body:(fun i -> Array.set a i (Random.float 1000.));
+  let pool = Task.setup_pool ~num_additional_domains:(num_domains-1) () in
+  Task.run pool (fun () -> Task.parallel_for pool ~chunk_size:(n/num_domains) ~start:0
+  ~finish:(n - 1) ~body:(fun i -> Array.set a i (Random.float 1000.)));
   Task.teardown_pool pool

--- a/code/profiling/float_init_par2.ml
+++ b/code/profiling/float_init_par2.ml
@@ -5,9 +5,9 @@ let num_domains = try int_of_string Sys.argv.(1) with _ -> 4
 let arr = Array.create_float n
 
 let _ =
-  let domains = T.setup_pool ~num_additional_domains:(num_domains - 1) in
+  let domains = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
   let states = Array.init num_domains (fun _ -> Random.State.make_self_init()) in
-  T.parallel_for domains ~chunk_size:(n/num_domains) ~start:0 ~finish:(n-1)
+  T.run domains @@ fun () -> T.parallel_for domains ~chunk_size:(n/num_domains) ~start:0 ~finish:(n-1)
   ~body:(fun i ->
     let d = (Domain.self() :> int) mod num_domains in
     Array.unsafe_set arr i (Random.State.float states.(d) 100. ))

--- a/code/profiling/float_init_par3.ml
+++ b/code/profiling/float_init_par3.ml
@@ -11,7 +11,7 @@ let init_part s e arr =
     done
 
 let _ =
-  let domains = T.setup_pool ~num_additional_domains:(num_domains - 1) in
-  T.parallel_for domains ~chunk_size:1 ~start:0 ~finish:(num_domains - 1)
-  ~body:(fun i -> init_part (i * n / num_domains) ((i+1) * n / num_domains - 1) arr);
+  let domains = T.setup_pool ~num_additional_domains:(num_domains - 1) () in
+  T.run domains (fun () -> T.parallel_for domains ~chunk_size:1 ~start:0 ~finish:(num_domains - 1)
+  ~body:(fun i -> init_part (i * n / num_domains) ((i+1) * n / num_domains - 1) arr));
   T.teardown_pool domains

--- a/code/task/fibonacci_multicore.ml
+++ b/code/task/fibonacci_multicore.ml
@@ -15,7 +15,7 @@ let rec fib_par pool n =
     Task.await pool a + Task.await pool b
 
 let main =
-  let pool = Task.setup_pool ~num_additional_domains:(num_domains - 1) in
-  let res = fib_par pool n in
+  let pool = Task.setup_pool ~num_additional_domains:(num_domains - 1) () in
+  let res = Task.run pool (fun () -> fib_par pool) n in
   Task.teardown_pool pool;
   Printf.printf "fib(%d) = %d\n" n res

--- a/code/task/matrix_multiplication_multicore.ml
+++ b/code/task/matrix_multiplication_multicore.ml
@@ -27,11 +27,8 @@ let print_matrix m =
   done
 
 let _ =
-    let pool = Task.setup_pool ~num_additional_domains:(num_domains - 1) in
+    let pool = Task.setup_pool ~num_additional_domains:(num_domains - 1) () in
     let m1 = Array.init n (fun _ -> Array.init n (fun _ -> Random.int 100)) in
     let m2 = Array.init n (fun _ -> Array.init n (fun _ -> Random.int 100)) in
-    (* print_matrix m1;
-    print_matrix m2; *)
-    let _ = parallel_matrix_multiply pool m1 m2 in
+    let _ = Task.run pool (fun () -> parallel_matrix_multiply pool m1 m2) in
     Task.teardown_pool pool
-    (* print_matrix m3; *)

--- a/code/task/three_matrix_multiplication.ml
+++ b/code/task/three_matrix_multiplication.ml
@@ -34,12 +34,12 @@ let print_matrix m =
   done
 
 let _ =
-    let pool = Task.setup_pool ~num_additional_domains:(num_domains - 1) in
+    let pool = Task.setup_pool ~num_additional_domains:(num_domains - 1) () in
     let m1 = Array.init n (fun _ -> Array.init n (fun _ -> Random.int 100)) in
     let m2 = Array.init n (fun _ -> Array.init n (fun _ -> Random.int 100)) in
     let m3 = Array.init n (fun _ -> Array.init n (fun _ -> Random.int 100)) in
     (* print_matrix m1;
     print_matrix m2; *)
-    let _ = parallel_matrix_multiply_3 pool m1 m2 m3 in
+    let _ = Task.run pool (fun () -> parallel_matrix_multiply_3 pool m1 m2 m3) in
     Task.teardown_pool pool
     (* print_matrix m3; *)


### PR DESCRIPTION
Fixes for the breaking changes introduced in `domainslib.0.4.0`. Introduction has also been updated to reflect the current plan for OCaml 5.